### PR TITLE
fixed issue with setStartAndEndDateWithParts

### DIFF
--- a/Ranger/src/main/java/com/andressantibanez/ranger/Ranger.java
+++ b/Ranger/src/main/java/com/andressantibanez/ranger/Ranger.java
@@ -209,6 +209,9 @@ public class Ranger extends HorizontalScrollView implements View.OnClickListener
         //Get inflater for view
         LayoutInflater inflater = LayoutInflater.from(mContext);
 
+        //Remove default view
+        mDaysContainer.removeAllViews();
+        
         //Add left padding
         mLeftSpace = new Space(mContext);
         mDaysContainer.addView(mLeftSpace);


### PR DESCRIPTION
There was an issue while using the function setStartAndEndDateWithParts(int startYear, int startMonth, int startDay, int endYear, int endMonth, int endDay). The desired date picker view came after the default date picker. I deleted the default view before adding the new view.
